### PR TITLE
Add PVC and workload checks to metrics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,9 @@
 * Compatible with OpenShift and Kubernetes.
 * Easily extensible with your own metrics.
 * Lightweight and containerized.
+* Detect unbound and pending PVCs.
+* Identify single-replica or un‑resourced workloads.
+* Report workloads using privileged ServiceAccounts.
 
 ## Architecture
 

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,15 @@ app = Flask(__name__, static_folder='static', template_folder='templates')
 
 subnet_cidr = "192.168.1.0/24"
 exclude_ns_patterns = []
-cache_results = {"np": [], "quota": []}
+cache_results = {
+    "np": [],
+    "quota": [],
+    "pvc_unbound": [],
+    "pvc_pending": [],
+    "single_replica": [],
+    "no_resources": [],
+    "priv_sa": []
+}
 cache_ips = {"nodes": [], "egress": []}
 
 ip_pool_total = Gauge('ip_pool_total', 'Total IPs available in the VLAN', registry=registry)
@@ -29,6 +37,41 @@ ns_without_np_total = Gauge('namespaces_without_networkpolicy_total', 'Total nam
 ns_without_np_label = Gauge('namespace_without_networkpolicy', 'Namespace without NetworkPolicy', ['namespace'], registry=registry)
 ns_quota_total = Gauge('namespaces_without_resourcequota_total', 'Total namespaces without ResourceQuotass', registry=registry)
 ns_quota_label = Gauge('namespace_without_resourcequota', 'Namespace without ResourceQuota', ['namespace'], registry=registry)
+
+# PVC metrics
+pvc_unbound_total = Gauge('pvc_unbound_total', 'Total PVCs in Lost or unbound state', registry=registry)
+pvc_unbound_info = Gauge('pvc_unbound', 'PVC in Lost/unbound state', ['namespace', 'pvc'], registry=registry)
+pvc_pending_total = Gauge('pvc_pending_total', 'Total PVCs pending', registry=registry)
+pvc_pending_info = Gauge('pvc_pending', 'PVC in Pending state', ['namespace', 'pvc'], registry=registry)
+
+# Workload metrics
+workload_single_replica_total = Gauge(
+    'workloads_single_replica_total',
+    'Total Deployments/StatefulSets with a single replica',
+    registry=registry)
+workload_single_replica_info = Gauge(
+    'workload_single_replica',
+    'Deployment/StatefulSet running with one replica',
+    ['namespace', 'app', 'kind'], registry=registry)
+
+workload_no_resources_total = Gauge(
+    'workloads_no_resources_total',
+    'Total Deployments/StatefulSets without resource requests/limits',
+    registry=registry)
+workload_no_resources_info = Gauge(
+    'workload_no_resources',
+    'Deployment/StatefulSet without resource requests/limits',
+    ['namespace', 'app', 'kind'], registry=registry)
+
+# Privileged service accounts metrics
+priv_sa_total = Gauge(
+    'privileged_serviceaccount_total',
+    'Total workloads using privileged service accounts',
+    registry=registry)
+priv_sa_info = Gauge(
+    'privileged_serviceaccount',
+    'Workload using privileged service account and SCC',
+    ['namespace', 'app', 'serviceaccount', 'scc'], registry=registry)
 
 def exclude_ns(ns):
     return any(fnmatch.fnmatch(ns, pattern) for pattern in exclude_ns_patterns)
@@ -41,8 +84,19 @@ def home():
     pie_data = f"{used},{ip_free},{total_ips}"
     ips = [{"type": "nodo", "ip": ip} for ip in cache_ips["nodes"]] + [{"type": "egress", "ip": ip} for ip in cache_ips["egress"]]
     ips = sorted(ips, key=lambda x: x["type"])
-    return render_template("home.html", subnet=subnet_cidr, pie_data=pie_data,
-                           np=cache_results["np"], quota=cache_results["quota"], ips=ips)
+    return render_template(
+        "home.html",
+        subnet=subnet_cidr,
+        pie_data=pie_data,
+        np=cache_results["np"],
+        quota=cache_results["quota"],
+        pvc_unbound=cache_results["pvc_unbound"],
+        pvc_pending=cache_results["pvc_pending"],
+        single_replica=cache_results["single_replica"],
+        no_resources=cache_results["no_resources"],
+        priv_sa=cache_results["priv_sa"],
+        ips=ips,
+    )
 
 @app.route("/metrics")
 def metrics():
@@ -60,6 +114,14 @@ def update_metrics():
         except Exception as e:
             logging.warning(f"❌ Error at {desc}: {e}")
             return []
+
+    def run_cmd_json(desc, cmd):
+        lines = run_cmd(desc, cmd)
+        try:
+            return json.loads("\n".join(lines)) if lines else {}
+        except Exception as e:
+            logging.warning(f"❌ JSON parse error at {desc}: {e}")
+            return {}
 
     # Egress IPs from spec.egressIPs
     #oc get egressip -A -o jsonpath='{range .items[*]}{.spec.egressIPs[*]}{"\n"}{end}'
@@ -103,6 +165,98 @@ def update_metrics():
     for ns in namespace_without_resourcequota:
         ns_quota_label.labels(namespace=ns).set(1)
 
+    # PVCs
+    pvc_data = run_cmd_json("pvcs", ["oc", "get", "pvc", "-A", "-o", "json"])
+    pvc_unbound = []
+    pvc_pending = []
+    for pvc in pvc_data.get("items", []):
+        ns = pvc["metadata"].get("namespace")
+        if exclude_ns(ns):
+            continue
+        name = pvc["metadata"]["name"]
+        phase = pvc.get("status", {}).get("phase", "").lower()
+        if phase == "pending":
+            pvc_pending.append({"namespace": ns, "name": name})
+        elif phase != "bound":
+            pvc_unbound.append({"namespace": ns, "name": name})
+    cache_results["pvc_unbound"] = [f"{p['namespace']}/{p['name']}" for p in pvc_unbound]
+    cache_results["pvc_pending"] = [f"{p['namespace']}/{p['name']}" for p in pvc_pending]
+    pvc_unbound_total.set(len(pvc_unbound))
+    pvc_pending_total.set(len(pvc_pending))
+    for p in pvc_unbound:
+        pvc_unbound_info.labels(namespace=p["namespace"], pvc=p["name"]).set(1)
+    for p in pvc_pending:
+        pvc_pending_info.labels(namespace=p["namespace"], pvc=p["name"]).set(1)
+
+    # Workloads (deployments and statefulsets)
+    deploys = run_cmd_json("deployments", ["oc", "get", "deploy", "-A", "-o", "json"])
+    sts = run_cmd_json("statefulsets", ["oc", "get", "statefulset", "-A", "-o", "json"])
+    single_replica = []
+    no_resources = []
+    workload_sa = []  # store sa for privileged check
+
+    def process_workloads(items, kind):
+        for it in items.get("items", []):
+            ns = it["metadata"].get("namespace")
+            if exclude_ns(ns):
+                continue
+            name = it["metadata"]["name"]
+            replicas = it.get("spec", {}).get("replicas", 1)
+            sa = it.get("spec", {}).get("template", {}).get("spec", {}).get("serviceAccountName", "default")
+            containers = it.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+            if replicas == 1:
+                single_replica.append({"namespace": ns, "name": name, "kind": kind})
+            missing = False
+            for c in containers:
+                res = c.get("resources", {})
+                if not res.get("requests") or not res.get("limits"):
+                    missing = True
+                    break
+            if missing:
+                no_resources.append({"namespace": ns, "name": name, "kind": kind})
+            workload_sa.append({"namespace": ns, "name": name, "sa": sa, "kind": kind})
+
+    process_workloads(deploys, "deployment")
+    process_workloads(sts, "statefulset")
+
+    cache_results["single_replica"] = [f"{w['namespace']}/{w['name']} ({w['kind']})" for w in single_replica]
+    cache_results["no_resources"] = [f"{w['namespace']}/{w['name']} ({w['kind']})" for w in no_resources]
+    workload_single_replica_total.set(len(single_replica))
+    workload_no_resources_total.set(len(no_resources))
+    for w in single_replica:
+        workload_single_replica_info.labels(namespace=w["namespace"], app=w["name"], kind=w["kind"]).set(1)
+    for w in no_resources:
+        workload_no_resources_info.labels(namespace=w["namespace"], app=w["name"], kind=w["kind"]).set(1)
+
+    # Privileged service accounts
+    sccs = run_cmd_json("scc", ["oc", "get", "scc", "-o", "json"])
+    privileged = {}
+    for scc in sccs.get("items", []):
+        scc_name = scc.get("metadata", {}).get("name")
+        if scc_name and scc_name.startswith("restricted"):
+            continue
+        for user in scc.get("users", []) or []:
+            if user.startswith("system:serviceaccount:"):
+                parts = user.split(":")
+                if len(parts) == 4:
+                    privileged[(parts[2], parts[3])] = scc_name
+
+    priv_list = []
+    for w in workload_sa:
+        key = (w["namespace"], w["sa"])
+        if key in privileged:
+            priv_list.append({
+                "namespace": w["namespace"],
+                "name": w["name"],
+                "sa": w["sa"],
+                "scc": privileged[key],
+            })
+
+    cache_results["priv_sa"] = priv_list
+    priv_sa_total.set(len(priv_list))
+    for p in priv_list:
+        priv_sa_info.labels(namespace=p["namespace"], app=p["name"], serviceaccount=p["sa"], scc=p["scc"]).set(1)
+
     Timer(60, update_metrics).start()
 
 def create_app(config_path=os.getenv("CONFIG_PATH", "config.json")):
@@ -113,7 +267,15 @@ def create_app(config_path=os.getenv("CONFIG_PATH", "config.json")):
 
     subnet_cidr = config.get("subnet", "192.168.1.0/24")
     exclude_ns_patterns = config.get("exclude_namespaces", [])
-    cache_results.update({"np": [], "quota": []})
+    cache_results.update({
+        "np": [],
+        "quota": [],
+        "pvc_unbound": [],
+        "pvc_pending": [],
+        "single_replica": [],
+        "no_resources": [],
+        "priv_sa": []
+    })
     return app
 
 if __name__ == "__main__":

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -120,6 +120,70 @@
       <p><i>No namespaces without ResourceQuota were found..</i></p>
       {% endif %}
     </div>
+
+    <div class="section">
+      <h2>PVCs Unbound</h2>
+      {% if pvc_unbound %}
+      <ul>{% for pvc in pvc_unbound %}<li>{{ pvc }}</li>{% endfor %}</ul>
+      {% else %}
+      <p><i>No unbound PVCs were found.</i></p>
+      {% endif %}
+    </div>
+
+    <div class="section">
+      <h2>PVCs Pending</h2>
+      {% if pvc_pending %}
+      <ul>{% for pvc in pvc_pending %}<li>{{ pvc }}</li>{% endfor %}</ul>
+      {% else %}
+      <p><i>No pending PVCs were found.</i></p>
+      {% endif %}
+    </div>
+
+    <div class="section">
+      <h2>Workloads with single replica</h2>
+      {% if single_replica %}
+      <ul>{% for w in single_replica %}<li>{{ w }}</li>{% endfor %}</ul>
+      {% else %}
+      <p><i>No single replica workloads were found.</i></p>
+      {% endif %}
+    </div>
+
+    <div class="section">
+      <h2>Workloads without resources</h2>
+      {% if no_resources %}
+      <ul>{% for w in no_resources %}<li>{{ w }}</li>{% endfor %}</ul>
+      {% else %}
+      <p><i>All workloads have resource requests and limits.</i></p>
+      {% endif %}
+    </div>
+
+    <div class="section">
+      <h2>Privileged ServiceAccounts</h2>
+      {% if priv_sa %}
+      <table>
+        <thead>
+          <tr>
+            <th>Namespace</th>
+            <th>App</th>
+            <th>ServiceAccount</th>
+            <th>SCC</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for sa in priv_sa %}
+          <tr>
+            <td>{{ sa.namespace }}</td>
+            <td>{{ sa.name }}</td>
+            <td>{{ sa.sa }}</td>
+            <td>{{ sa.scc }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p><i>No workloads using privileged service accounts were found.</i></p>
+      {% endif %}
+    </div>
   </div>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,13 +12,20 @@ def client():
 
 @mock.patch("subprocess.check_output")
 def test_metrics(mock_check_output, client):
+    pvc_json = b'{"items":[{"metadata":{"namespace":"ns1","name":"pvc1"},"status":{"phase":"Pending"}},{"metadata":{"namespace":"ns1","name":"pvc2"},"status":{"phase":"Lost"}}]}'
+    deploy_json = b'{"items":[{"metadata":{"namespace":"ns1","name":"app1"},"spec":{"replicas":1,"template":{"spec":{"serviceAccountName":"sa1","containers":[{"name":"c1"}]}}}},{"metadata":{"namespace":"ns1","name":"app2"},"spec":{"replicas":2,"template":{"spec":{"serviceAccountName":"sa2","containers":[{"name":"c2","resources":{"requests":{"cpu":"10m"},"limits":{"cpu":"20m"}}}]}}}}]}'
+    sts_json = b'{"items":[]}'
+    scc_json = b'{"items":[{"metadata":{"name":"privileged"},"users":["system:serviceaccount:ns1:sa1"]}]}'
     mock_check_output.side_effect = [
         b"192.168.1.100\n192.168.1.101",  # egressip
         b"node1\nnode2",                  # nodes
-        b"default\nkube-system\nns1",     # namespaces
-        b"",                              # networkpolicy
-        b"pod1 0/1 CrashLoopBackOff",     # pods
-        b""                               # resourcequota
+        b"ns1",                            # namespaces
+        b"",                               # networkpolicy
+        b"",                               # resourcequota
+        pvc_json,
+        deploy_json,
+        sts_json,
+        scc_json
     ]
 
     response = client.get("/metrics")
@@ -26,11 +33,18 @@ def test_metrics(mock_check_output, client):
     assert b"ip_pool_total" in response.data
     assert b'egressips_used' in response.data
     assert b'nodesips_used' in response.data
+    assert b'pvc_unbound_total' in response.data
+    assert b'pvc_pending_total' in response.data
+    assert b'workloads_single_replica_total' in response.data
+    assert b'workloads_no_resources_total' in response.data
+    assert b'privileged_serviceaccount_total' in response.data
 
 def test_home(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert "EgressIP Metrics" in response.data.decode("utf-8")
+    body = response.data.decode("utf-8")
+    assert "EgressIP Metrics" in body
+    assert "PVCs Unbound" in body
 
 def test_metrics_format(client):
     response = client.get("/metrics")
@@ -42,11 +56,18 @@ def test_metrics_format(client):
 
 @mock.patch("subprocess.check_output")
 def test_metrics_namespace_filtering(mock_check_output, client):
+    pvc_json = b'{"items":[]}'
+    empty_json = b'{"items":[]}'
     mock_check_output.side_effect = [
         b"192.168.1.10",         # egressip
         b"node1",                # nodes
         b"default\nns-user\nopenshift-monitoring",  # namespaces
-        b"", b"", b""            # remaining subprocess calls
+        b"",                     # networkpolicy ns-user
+        b"",                     # resourcequota ns-user
+        pvc_json,                # pvcs
+        empty_json,              # deploy
+        empty_json,              # sts
+        b'{"items":[]}'         # scc
     ]
 
     response = client.get("/metrics")


### PR DESCRIPTION
## Summary
- surface more cluster metrics about PVCs, workloads and serviceaccounts
- extend web dashboard to display new metric lists
- document new features in README
- update tests for new metrics

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841afee3f9083229d01f6b337d6b335