### PR TITLE
Update home tables and track PV unbound

### DIFF
--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -106,7 +106,14 @@
     <div class="section">
       <h2>Namespaces without NetworkPolicy</h2>
       {% if np %}
-      <ul>{% for ns in np %}<li>{{ ns }}</li>{% endfor %}</ul>
+      <table>
+        <thead><tr><th>Namespace</th></tr></thead>
+        <tbody>
+          {% for ns in np %}
+          <tr><td>{{ ns }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
       {% else %}
       <p><i>No namespaces without networkpolicy were found.</i></p>
       {% endif %}
@@ -115,25 +122,46 @@
     <div class="section">
       <h2>Namespaces without ResourceQuota</h2>
       {% if quota %}
-      <ul>{% for ns in quota %}<li>{{ ns }}</li>{% endfor %}</ul>
+      <table>
+        <thead><tr><th>Namespace</th></tr></thead>
+        <tbody>
+          {% for ns in quota %}
+          <tr><td>{{ ns }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
       {% else %}
       <p><i>No namespaces without ResourceQuota were found..</i></p>
       {% endif %}
     </div>
 
     <div class="section">
-      <h2>PVCs Unbound</h2>
-      {% if pvc_unbound %}
-      <ul>{% for pvc in pvc_unbound %}<li>{{ pvc }}</li>{% endfor %}</ul>
+      <h2>PV Unbound</h2>
+      {% if pv_unbound %}
+      <table>
+        <thead><tr><th>PersistentVolume</th></tr></thead>
+        <tbody>
+          {% for pv in pv_unbound %}
+          <tr><td>{{ pv }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
       {% else %}
-      <p><i>No unbound PVCs were found.</i></p>
+      <p><i>No unbound PVs were found.</i></p>
       {% endif %}
     </div>
 
     <div class="section">
       <h2>PVCs Pending</h2>
       {% if pvc_pending %}
-      <ul>{% for pvc in pvc_pending %}<li>{{ pvc }}</li>{% endfor %}</ul>
+      <table>
+        <thead><tr><th>Namespace</th><th>PVC</th></tr></thead>
+        <tbody>
+          {% for pvc in pvc_pending %}
+          <tr><td>{{ pvc.namespace }}</td><td>{{ pvc.name }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
       {% else %}
       <p><i>No pending PVCs were found.</i></p>
       {% endif %}
@@ -142,7 +170,14 @@
     <div class="section">
       <h2>Workloads with single replica</h2>
       {% if single_replica %}
-      <ul>{% for w in single_replica %}<li>{{ w }}</li>{% endfor %}</ul>
+      <table>
+        <thead><tr><th>Namespace</th><th>App</th><th>Kind</th></tr></thead>
+        <tbody>
+          {% for w in single_replica %}
+          <tr><td>{{ w.namespace }}</td><td>{{ w.name }}</td><td>{{ w.kind }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
       {% else %}
       <p><i>No single replica workloads were found.</i></p>
       {% endif %}
@@ -151,7 +186,14 @@
     <div class="section">
       <h2>Workloads without resources</h2>
       {% if no_resources %}
-      <ul>{% for w in no_resources %}<li>{{ w }}</li>{% endfor %}</ul>
+      <table>
+        <thead><tr><th>Namespace</th><th>App</th><th>Kind</th></tr></thead>
+        <tbody>
+          {% for w in no_resources %}
+          <tr><td>{{ w.namespace }}</td><td>{{ w.name }}</td><td>{{ w.kind }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
       {% else %}
       <p><i>All workloads have resource requests and limits.</i></p>
       {% endif %}


### PR DESCRIPTION
## Summary
- show data in tables for namespaces, PVCs, PVs and workloads
- track unbound PVs instead of PVCs and expose new metric
- adjust tests for PV unbound

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b3fc406c83229f7b51516a1df343