### PR TITLE
Add expiry date info to route cert metric

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,7 +120,7 @@ The service exposes metrics at `http://<service-name>.<namespace>.svc.cluster.lo
 | `privileged_serviceaccount_total` | Workloads using privileged ServiceAccounts | - | `privileged_serviceaccount_total 1` |
 | `privileged_serviceaccount` | Workload with privileged SA and SCC | `namespace`,`app`,`serviceaccount`,`scc` | `privileged_serviceaccount{namespace="dev",app="web",serviceaccount="sa",scc="privileged"} 1` |
 | `routes_cert_expiring_total` | HTTPS routes with certificates nearing expiry | - | `routes_cert_expiring_total 1` |
-| `route_cert_expiry_timestamp` | Expiration time of route TLS certificate (unix) | `namespace`,`route`,`host` | `route_cert_expiry_timestamp{namespace="dev",route="web",host="web.example.com"} 1700000000` |
+| `route_cert_expiry_timestamp` | Days until route TLS certificate expiry (label `expiry_date` shows the date) | `namespace`,`route`,`host`,`expiry_date` | `route_cert_expiry_timestamp{namespace="dev",route="web",host="web.example.com",expiry_date="2025-06-30"} 120` |
 
 ## Contributing
 

--- a/prometheus-rules/route-cert-rules.yaml
+++ b/prometheus-rules/route-cert-rules.yaml
@@ -8,7 +8,7 @@ spec:
   - name: route-cert-expiry
     rules:
     - alert: RouteCertificateExpiringSoon
-      expr: (route_cert_expiry_timestamp - time()) < 15552000
+      expr: route_cert_expiry_timestamp < 180
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
## Summary
- extend `route_cert_expiry_timestamp` metric with `expiry_date` label
- return days until expiry for route cert metrics
- adjust Prometheus rule for new metric semantics
- document updated metric

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a85232588322b9c7eed3890e5ba5