### PR TITLE
Handle SCC rolebindings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,6 +120,7 @@ The service exposes metrics at `http://<service-name>.<namespace>.svc.cluster.lo
 | `workload_no_resources` | Workload without resources | `namespace`,`app`,`kind` | `workload_no_resources{namespace="dev",app="web",kind="statefulset"} 1` |
 | `privileged_serviceaccount_total` | Workloads using privileged ServiceAccounts | - | `privileged_serviceaccount_total 1` |
 | `privileged_serviceaccount` | Workload with privileged SA and SCC | `namespace`,`app`,`serviceaccount`,`scc` | `privileged_serviceaccount{namespace="dev",app="web",serviceaccount="sa",scc="privileged"} 1` |
+|  | *Service accounts referenced by `system:openshift:scc:<name>` RoleBindings or ClusterRoleBindings are also mapped to their SCC* | |
 | `routes_cert_expiring_total` | HTTPS routes with certificates nearing expiry | - | `routes_cert_expiring_total 1` |
 | `route_cert_expiry_timestamp` | Days until route TLS certificate expiry (label `expiry_date` shows the date) | `namespace`,`route`,`host`,`expiry_date` | `route_cert_expiry_timestamp{namespace="dev",route="web",host="web.example.com",expiry_date="2025-06-30"} 120` |
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -139,6 +139,8 @@ def test_workloads_processed_once(mock_check_output, mock_cert, mock_timer, clie
     pvc_json = '{"items":[]}'
     pv_json = '{"items":[]}'
     scc_json = '{"items":[{"metadata":{"name":"privileged"},"users":["system:serviceaccount:ns1:sa1"]}]}'
+    rb_json = '{"items":[{"metadata":{"namespace":"ns1"},"roleRef":{"name":"system:openshift:scc:privileged"},"subjects":[{"kind":"ServiceAccount","name":"sa1"}]}]}'
+    crb_json = '{"items":[]}'
     route_json = '{"items":[]}'
 
     mock_cert.return_value = int(time.time()) + 60 * 86400
@@ -153,6 +155,8 @@ def test_workloads_processed_once(mock_check_output, mock_cert, mock_timer, clie
         deploy_json,
         sts_json,
         scc_json,
+        rb_json,
+        crb_json,
         route_json,
     ]
 

--- a/tests/test_update_metrics.py
+++ b/tests/test_update_metrics.py
@@ -3,6 +3,7 @@ import time
 from unittest import mock
 
 import app.app as app_module
+from prometheus_client import generate_latest
 
 
 @mock.patch("app.app.Timer")
@@ -14,6 +15,8 @@ def test_update_metrics(mock_check_output, mock_cert, mock_timer):
     deploy_json = b'{"items":[{"metadata":{"namespace":"ns1","name":"app1"},"spec":{"replicas":1,"template":{"spec":{"serviceAccountName":"sa1","containers":[{"name":"c1"}]}}}},{"metadata":{"namespace":"ns1","name":"app2"},"spec":{"replicas":2,"template":{"spec":{"serviceAccountName":"sa2","containers":[{"name":"c2","resources":{"requests":{"cpu":"10m"},"limits":{"cpu":"20m"}}}]}}}}]}'
     sts_json = b'{"items":[]}'
     scc_json = b'{"items":[{"metadata":{"name":"privileged"},"users":["system:serviceaccount:ns1:sa1"]}]}'
+    rb_json = b'{"items":[{"metadata":{"namespace":"ns1"},"roleRef":{"name":"system:openshift:scc:privileged"},"subjects":[{"kind":"ServiceAccount","name":"sa2"}]}]}'
+    crb_json = b'{"items":[]}'
     route_json = b'{"items":[{"metadata":{"namespace":"ns1","name":"r1"},"spec":{"host":"r1.example.com","tls":{"certificate":"dummy"}}}]}'
 
     mock_timer.return_value.start.return_value = None
@@ -29,6 +32,8 @@ def test_update_metrics(mock_check_output, mock_cert, mock_timer):
         deploy_json.decode(),
         sts_json.decode(),
         scc_json.decode(),
+        rb_json.decode(),
+        crb_json.decode(),
         route_json.decode(),
     ]
 
@@ -43,3 +48,6 @@ def test_update_metrics(mock_check_output, mock_cert, mock_timer):
     assert app_module.workload_no_resources_total._value.get() == 2
     assert app_module.priv_sa_total._value.get() == 2
     assert app_module.routes_cert_expiring_total._value.get() == 1
+
+    metrics = app_module.generate_latest(app_module.registry).decode("utf-8")
+    assert 'serviceaccount="sa2"' in metrics


### PR DESCRIPTION
## Summary
- detect service accounts bound to `system:openshift:scc:<name>` roles
- merge these RBAC mappings with SCC `users` lookup so privileged metrics reflect bindings
- test privileged service accounts bound through RoleBindings
- document that RoleBindings/ClusterRoleBindings are considered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848065295f08322ad67cbcaef99bac2