### PR TITLE
Implement anti-affinity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Initial changelog file.
 * Refactored README with project description, images, and usage.
 * CONTRIBUTING and TODO markdown files.
+* Detection of workloads without anti-affinity rules.
 
 ### Planned
 

--- a/Readme.md
+++ b/Readme.md
@@ -87,7 +87,8 @@ data:
         "pvc_pending": true,
         "single_replica": true,
         "no_resources": true,
-        "priv_sa": true
+        "priv_sa": true,
+        "no_antiaffinity": true
       },
       "update_seconds": 60,
       "scc_types": ["restricted", "anyuid", "hostaccess", "hostmount-anyuid", "privileged"]
@@ -118,6 +119,8 @@ The service exposes metrics at `http://<service-name>.<namespace>.svc.cluster.lo
 | `workload_single_replica` | Workload with one replica | `namespace`,`app`,`kind` | `workload_single_replica{namespace="dev",app="web",kind="deployment"} 1` |
 | `workloads_no_resources_total` | Workloads missing resource requests/limits | - | `workloads_no_resources_total 1` |
 | `workload_no_resources` | Workload without resources | `namespace`,`app`,`kind` | `workload_no_resources{namespace="dev",app="web",kind="statefulset"} 1` |
+| `workloads_no_antiaffinity_total` | Workloads lacking anti-affinity rules | - | `workloads_no_antiaffinity_total 1` |
+| `workload_no_antiaffinity` | Workload without anti-affinity | `namespace`,`app`,`kind` | `workload_no_antiaffinity{namespace="dev",app="web",kind="deployment"} 1` |
 | `privileged_serviceaccount_total` | Workloads using privileged ServiceAccounts | - | `privileged_serviceaccount_total 1` |
 | `privileged_serviceaccount` | Workload with privileged SA and SCC | `namespace`,`app`,`serviceaccount`,`scc` | `privileged_serviceaccount{namespace="dev",app="web",serviceaccount="sa",scc="privileged"} 1` |
 |  | *Service accounts referenced by `system:openshift:scc:<name>` RoleBindings or ClusterRoleBindings are also mapped to their SCC* | |

--- a/app/config.json
+++ b/app/config.json
@@ -9,6 +9,7 @@
         "single_replica": [],
         "no_resources": [],
         "priv_sa": [],
+        "no_antiaffinity": [],
         "route_cert": []
     },
     "enabled_features": {
@@ -19,6 +20,7 @@
         "single_replica": true,
         "no_resources": true,
         "priv_sa": true,
+        "no_antiaffinity": true,
         "route_cert": true
     },
     "update_seconds": 60,

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -200,6 +200,22 @@
     </div>
 
     <div class="section">
+      <h2>Workloads without anti-affinity</h2>
+      {% if no_antiaffinity %}
+      <table>
+        <thead><tr><th>Namespace</th><th>App</th><th>Kind</th></tr></thead>
+        <tbody>
+          {% for w in no_antiaffinity %}
+          <tr><td>{{ w.namespace }}</td><td>{{ w.name }}</td><td>{{ w.kind }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p><i>No workloads missing anti-affinity rules were found.</i></p>
+      {% endif %}
+    </div>
+
+    <div class="section">
       <h2>Privileged ServiceAccounts</h2>
       {% if priv_sa %}
       <table>

--- a/deploy/2_configmap.yaml
+++ b/deploy/2_configmap.yaml
@@ -17,6 +17,7 @@ data:
             "single_replica": [],
             "no_resources": [],
             "priv_sa": [],
+            "no_antiaffinity": [],
             "route_cert": []
         },
         "enabled_features": {
@@ -27,6 +28,7 @@ data:
             "single_replica": true,
             "no_resources": true,
             "priv_sa": true,
+            "no_antiaffinity": true,
             "route_cert": true
         },
         "update_seconds": 60,

--- a/tests/config_disabled.json
+++ b/tests/config_disabled.json
@@ -9,6 +9,7 @@
     "single_replica": [],
     "no_resources": [],
     "priv_sa": [],
+    "no_antiaffinity": [],
     "route_cert": []
   },
   "enabled_features": {
@@ -19,6 +20,7 @@
     "single_replica": false,
     "no_resources": false,
     "priv_sa": false,
+    "no_antiaffinity": false,
     "route_cert": false
   },
   "update_seconds": 60,

--- a/tests/config_test.json
+++ b/tests/config_test.json
@@ -10,6 +10,7 @@
     "single_replica": [],
     "no_resources": [],
     "priv_sa": [],
+    "no_antiaffinity": [],
     "route_cert": []
   },
   "enabled_features": {
@@ -20,6 +21,7 @@
     "single_replica": true,
     "no_resources": true,
     "priv_sa": true,
+    "no_antiaffinity": true,
     "route_cert": true
   },
   "update_seconds": 60,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,6 +53,7 @@ def test_metrics(mock_check_output, mock_cert, client):
     assert b'pvc_pending_total' in response.data
     assert b'workloads_single_replica_total' in response.data
     assert b'workloads_no_resources_total' in response.data
+    assert b'workloads_no_antiaffinity_total' in response.data
     assert b'privileged_serviceaccount_total' in response.data
     assert b'routes_cert_expiring_total' in response.data
 
@@ -114,6 +115,7 @@ def test_feature_toggle(mock_check_output, client_disabled):
     assert "pv_unbound_total 0.0" in body
     assert "pvc_pending_total 0.0" in body
     assert "workloads_single_replica_total 0.0" in body
+    assert "workloads_no_antiaffinity_total 0.0" in body
     assert "privileged_serviceaccount_total 0.0" in body
     assert "routes_cert_expiring_total 0.0" in body
     # IP metrics still available
@@ -165,3 +167,6 @@ def test_workloads_processed_once(mock_check_output, mock_cert, mock_timer, clie
     expected_label = 'workload_single_replica{app="app1",kind="deployment",namespace="ns1"} 1.0'
     assert "workloads_single_replica_total 1.0" in metrics
     assert metrics.count(expected_label) == 1
+    expected_aff_label = 'workload_no_antiaffinity{app="app1",kind="deployment",namespace="ns1"} 1.0'
+    assert "workloads_no_antiaffinity_total 1.0" in metrics
+    assert metrics.count(expected_aff_label) == 1

--- a/tests/test_update_metrics.py
+++ b/tests/test_update_metrics.py
@@ -46,6 +46,7 @@ def test_update_metrics(mock_check_output, mock_cert, mock_timer):
     assert app_module.pvc_pending_total._value.get() == 1
     assert app_module.workload_single_replica_total._value.get() == 2
     assert app_module.workload_no_resources_total._value.get() == 2
+    assert app_module.workload_no_antiaffinity_total._value.get() == 2
     assert app_module.priv_sa_total._value.get() == 2
     assert app_module.routes_cert_expiring_total._value.get() == 1
 


### PR DESCRIPTION
## Summary
- detect workloads without anti-affinity
- graph them in the HTML dashboard
- expose `workloads_no_antiaffinity_total` and `workload_no_antiaffinity` metrics
- allow namespace exclusions for this feature
- document new metrics and configuration options
- test anti-affinity metrics

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848362de45083229b39f31cf51fde1f