### PR TITLE
Switch to openshift-client

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,7 @@
 * Compatible with OpenShift and Kubernetes.
 * Easily extensible with your own metrics.
 * Lightweight and containerized.
+* Uses the Python `openshift-client` library instead of relying on the `oc` binary.
 * Detect unbound and pending PVCs.
 * Identify single-replica or un‑resourced workloads.
 * Report workloads using privileged ServiceAccounts.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -21,11 +21,6 @@ RUN  microdnf update -y && \
     microdnf clean all && \
     rm -rf /root/.cache
 
-#oc
-RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz \
-    | tar -xz -C /usr/local/bin oc && \
-    chmod +x /usr/local/bin/oc
-
 USER 1001
 
 # Copiar archivos de la app

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -8,3 +8,4 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 prometheus_client==0.22.0
 Werkzeug==3.1.3
+openshift-client==2.0.5


### PR DESCRIPTION
## Summary
- swap `openshift` dependency for `openshift-client`
- lazy import Kubernetes/OpenShift packages so tests run without them
- document new dependency in README
- fix tests by importing `json`
- bump openshift-client version to 2.0.5

## Testing
- `python3 -m pip install -r tests/requirements.txt` *(fails: No matching distribution found for pytest-mock)*
- `PYTHONPATH=. pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_685c0bf13ef48322b4a555bd912af8c7