### PR TITLE
Align CI Python with runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install Python dependencies for testing
         run: |


### PR DESCRIPTION
## Summary
- run tests with `PYTHONPATH=./`
- update CI workflow to use Python 3.12

## Testing
- `PYTHONPATH=./ pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8593aacc83228b22e855ba5ae71d