### PR TITLE
Fix client initialization

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@
 * Compatible with OpenShift and Kubernetes.
 * Easily extensible with your own metrics.
 * Lightweight and containerized.
-* Uses the Python `openshift-client` library instead of relying on the `oc` binary.
+* Uses the Python `openshift-client` library. The `oc` CLI must be installed as it is invoked internally.
 * Detect unbound and pending PVCs.
 * Identify single-replica or un‑resourced workloads.
 * Report workloads using privileged ServiceAccounts.
@@ -41,6 +41,9 @@ This component is deployed as a Kubernetes Deployment and configured with a Conf
 
 * Kubernetes or OpenShift cluster (recomended)
 * Prometheus Operator installed
+* `oc` CLI available in the container or host running the exporter.
+  Use the `OPENSHIFT_CLIENT_PYTHON_DEFAULT_OC_PATH` environment variable to
+  specify the binary location if it is not in `PATH`.
 * Access to create namespaces, configmaps, and deployments
 
 ## Installation

--- a/app/app.py
+++ b/app/app.py
@@ -10,6 +10,9 @@ import datetime
 import time
 from threading import Timer
 import importlib
+import shutil
+
+_oc_lib = None
 from flask import Flask, Response, render_template
 from prometheus_client import Gauge, generate_latest, CollectorRegistry
 
@@ -20,26 +23,19 @@ logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(mes
 
 app = Flask(__name__, static_folder='static', template_folder='templates')
 
-_dyn_client = None
-
 def get_client():
-    """Return a cached OpenShift client instance."""
-    global _dyn_client
-    if _dyn_client is None:
+    """Return the cached openshift-client module and verify oc binary."""
+    global _oc_lib
+    if _oc_lib is None:
         try:
-            oc_mod = importlib.import_module("openshift_client.client")
-            k8s_config = importlib.import_module("kubernetes.config")
-            k8s_client = importlib.import_module("kubernetes.client")
+            _oc_lib = importlib.import_module("openshift_client")
         except Exception as exc:
             raise RuntimeError("openshift-client library is required") from exc
 
-        try:
-            k8s_config.load_incluster_config()
-        except Exception:
-            k8s_config.load_kube_config()
-
-        _dyn_client = oc_mod.OpenShiftClient(k8s_client.ApiClient())
-    return _dyn_client
+        oc_bin = os.getenv("OPENSHIFT_CLIENT_PYTHON_DEFAULT_OC_PATH", "oc")
+        if shutil.which(oc_bin) is None:
+            raise RuntimeError("oc CLI is required by openshift-client")
+    return _oc_lib
 
 RESOURCE_DEF = {
     "egressip": {"api_version": "k8s.ovn.org/v1", "kind": "EgressIP"},
@@ -58,12 +54,11 @@ RESOURCE_DEF = {
 }
 
 def fetch_resource(name, namespace=None):
-    info = RESOURCE_DEF[name]
-    cli = get_client()
-    res = cli.resources.get(api_version=info["api_version"], kind=info["kind"])
+    oc = get_client()
     if namespace:
-        return res.get(namespace=namespace).to_dict()
-    return res.get().to_dict()
+        with oc.project(namespace):
+            return json.loads(oc.selector(name).object_json())
+    return json.loads(oc.selector(name, all_namespaces=True).object_json())
 
 @app.template_filter('datetime')
 def _format_datetime(value):

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,4 +9,4 @@ MarkupSafe==3.0.2
 prometheus_client==0.22.0
 Werkzeug==3.1.3
 openshift-client==2.0.5
-kubernetes==33.1.0
+


### PR DESCRIPTION
## Summary
- use openshift-client module
- update requirements
- revise README to mention openshift-client
- Document oc requirement and check at runtime
- clarify oc binary path via env var

## Testing
- `python -m pip install -r tests/requirements.txt` *(fails: Could not install due to network)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e89eef8c08322881dc313caa8335d