### PR TITLE
Improve command helpers and tests

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -175,26 +175,30 @@ def get_cert_expiry(cert_pem: str) -> int:
         logging.warning(f"Could not parse certificate expiry: {e}")
     return 0
 
+def run_cmd(desc, cmd):
+    """Execute a command and return the output lines or an empty list."""
+    try:
+        logging.debug(f"➡️ Running: {' '.join(cmd)}")
+        result = subprocess.check_output(cmd, text=True)
+        logging.debug(f"✅ Result {desc}:{result.strip()}")
+        return result.strip().splitlines()
+    except Exception as e:
+        logging.warning(f"❌ Error at {desc}: {e}")
+        return []
+
+
+def run_cmd_json(desc, cmd):
+    """Run a command expected to return JSON and parse it."""
+    lines = run_cmd(desc, cmd)
+    try:
+        return json.loads("\n".join(lines)) if lines else {}
+    except Exception as e:
+        logging.warning(f"❌ JSON parse error at {desc}: {e}")
+        return {}
+
+
 def update_metrics():
     logging.debug("⏳ Running periodic metrics update")
-
-    def run_cmd(desc, cmd):
-        try:
-            logging.debug(f"➡️ Running: {' '.join(cmd)}")
-            result = subprocess.check_output(cmd, text=True)
-            logging.debug(f"✅ Result {desc}:{result.strip()}")
-            return result.strip().splitlines()
-        except Exception as e:
-            logging.warning(f"❌ Error at {desc}: {e}")
-            return []
-
-    def run_cmd_json(desc, cmd):
-        lines = run_cmd(desc, cmd)
-        try:
-            return json.loads("\n".join(lines)) if lines else {}
-        except Exception as e:
-            logging.warning(f"❌ JSON parse error at {desc}: {e}")
-            return {}
 
     # Egress IPs from spec.egressIPs
     #oc get egressip -A -o jsonpath='{range .items[*]}{.spec.egressIPs[*]}{"\n"}{end}'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,3 +46,25 @@ def test_format_datetime_valid():
 
 def test_format_datetime_invalid():
     assert app_module._format_datetime('bad') == ''
+
+
+@mock.patch('subprocess.check_output')
+def test_run_cmd_success(mock_co):
+    mock_co.return_value = 'a\nb\n'
+    assert app_module.run_cmd('desc', ['cmd']) == ['a', 'b']
+
+
+@mock.patch('subprocess.check_output', side_effect=Exception('boom'))
+def test_run_cmd_failure(mock_co):
+    assert app_module.run_cmd('desc', ['cmd']) == []
+
+
+@mock.patch('app.app.run_cmd')
+def test_run_cmd_json_success(mock_run):
+    mock_run.return_value = ['{"k": 1}']
+    assert app_module.run_cmd_json('d', ['cmd']) == {"k": 1}
+
+
+@mock.patch('app.app.run_cmd', return_value=['bad'])
+def test_run_cmd_json_invalid(mock_run):
+    assert app_module.run_cmd_json('d', ['cmd']) == {}


### PR DESCRIPTION
## Summary
- refactor `run_cmd` and `run_cmd_json` as standalone helpers
- add unit tests for the command helpers
- ensure newline at EOF for `app/app.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606669780c83229f70e11f215189ba